### PR TITLE
App Version Mock Add Function

### DIFF
--- a/src/mocks/appVersion.js
+++ b/src/mocks/appVersion.js
@@ -6,6 +6,11 @@ ngCordovaMocks.factory('$cordovaAppVersion', ['$q', function ($q) {
       var defer = $q.defer();
       defer.resolve('mock v');
       return defer.promise;
+    },
+    getVersionNumber: function() {
+      var defer = $q.defer();
+      defer.resolve('0.0.0');
+      return defer.promise;
     }
   };
 }]);


### PR DESCRIPTION
App Version mock doesn’t have getVersionNumber, added
